### PR TITLE
Scaffold faction flow society engine skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# Top-down
+# Faction Flow Society Engine
+
+An early skeleton for a digital society simulator that unites citizens into factions through daily polls, communal scoring, and lore-infused analytics.
+
+## Structure
+- `frontend/` – Next.js plaza housing faction-facing components.
+- `backend/` – Express gateway orchestrating poll, response, and faction summary routes.
+- `db/` – Postgres tablets defining the core tables.
+- `scripts/` – Analytics rituals run by the Midnight Assembly.
+
+Each module embraces faction-flavored naming to keep the narrative spirit alive while leaving room for real integrations later on.

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,22 @@
+const express = require("express");
+const bodyParser = require("body-parser");
+const pollRoutes = require("./routes/pollRoutes");
+const responseRoutes = require("./routes/responseRoutes");
+const factionRoutes = require("./routes/factionRoutes");
+
+// The Convergence Gateway routes all faction communications here.
+const app = express();
+app.use(bodyParser.json());
+
+app.use("/polls", pollRoutes);
+app.use("/responses", responseRoutes);
+app.use("/factions", factionRoutes);
+
+app.get("/status", (_req, res) => {
+  res.json({
+    status: "Faction Flow Society Engine humming",
+    timestamp: new Date().toISOString(),
+  });
+});
+
+module.exports = app;

--- a/backend/bots/guardianBot.js
+++ b/backend/bots/guardianBot.js
@@ -1,0 +1,10 @@
+// guardianBot: Defender of the Nexus, scanning for threats in faction sentiment.
+// Future upgrade: link to sentiment analysis models and anomaly detection.
+module.exports = function guardianBot(responses = []) {
+  return {
+    name: "Guardian Sentience",
+    vigilanceIndex: Math.min(1, responses.length * 0.05),
+    shieldIntegrity: 0.92,
+    notes: "Standing watch over the communal heartwood.",
+  };
+};

--- a/backend/bots/harmonizerBot.js
+++ b/backend/bots/harmonizerBot.js
@@ -1,0 +1,10 @@
+// harmonizerBot: Tunes the emotional symphony of the society, seeking balance.
+// Future upgrade: connect to emotional intelligence APIs and wellness monitors.
+module.exports = function harmonizerBot(responses = []) {
+  return {
+    name: "Harmonizer Chorus",
+    empathyWave: responses.length ? 0.55 + responses.length * 0.01 : 0.55,
+    resonanceField: "empathetic",
+    notes: "Listening to the heartbeats between the data points.",
+  };
+};

--- a/backend/bots/pioneerBot.js
+++ b/backend/bots/pioneerBot.js
@@ -1,0 +1,10 @@
+// pioneerBot: Cartographer of new social territories, forecasting engagement routes.
+// Future upgrade: plug into growth projection models.
+module.exports = function pioneerBot(pollMeta = {}) {
+  return {
+    name: "Pioneer Wayfinder",
+    explorationPotential: 0.67,
+    beaconSignals: pollMeta.options ? pollMeta.options.length / 10 : 0.2,
+    notes: "Charting paths for tomorrow's experiments.",
+  };
+};

--- a/backend/bots/strategistBot.js
+++ b/backend/bots/strategistBot.js
@@ -1,0 +1,11 @@
+// strategistBot: Keeper of the tactical playbook, simulating faction counter-moves.
+// Future upgrade: integrate with reinforcement learning war games.
+module.exports = function strategistBot(summary = {}) {
+  const factions = Object.keys(summary);
+  return {
+    name: "Strategist Oracle",
+    calculatedEquilibrium: factions.length / 10,
+    riskAlerts: factions.filter((key) => (summary[key]?.participation || 0) < 0.5),
+    notes: "Calculating the quiet before each maneuver.",
+  };
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "faction-flow-engine-backend",
+  "version": "0.1.0",
+  "description": "Express gateway for the Faction Flow Society Engine",
+  "main": "server.js",
+  "scripts": {
+    "dev": "node server.js"
+  },
+  "dependencies": {
+    "body-parser": "^1.20.2",
+    "express": "^4.18.2"
+  }
+}

--- a/backend/routes/factionRoutes.js
+++ b/backend/routes/factionRoutes.js
@@ -1,0 +1,16 @@
+const express = require("express");
+
+// Faction routes: recount the aggregated feats of each guild.
+const router = express.Router();
+
+router.get("/summary", (_req, res) => {
+  // TODO: Replace with dynamic aggregation from the Supabase citadel.
+  res.json({
+    guardians: { participation: 0.76, mood: "optimistic" },
+    pioneers: { participation: 0.62, mood: "neutral" },
+    strategists: { participation: 0.81, mood: "focused" },
+    harmonizers: { participation: 0.55, mood: "empathetic" },
+  });
+});
+
+module.exports = router;

--- a/backend/routes/pollRoutes.js
+++ b/backend/routes/pollRoutes.js
@@ -1,0 +1,21 @@
+const express = require("express");
+
+// Poll routes: handle the forging of new daily dilemmas.
+const router = express.Router();
+
+router.post("/create", (req, res) => {
+  const { question_text, options_json } = req.body;
+
+  // TODO: Integrate with the Supabase oracle to persist polls.
+  res.status(201).json({
+    message: "Poll cast into the Faction Flow archives.",
+    poll: {
+      id: Date.now(),
+      question_text,
+      options_json,
+      created_at: new Date().toISOString(),
+    },
+  });
+});
+
+module.exports = router;

--- a/backend/routes/responseRoutes.js
+++ b/backend/routes/responseRoutes.js
@@ -1,0 +1,22 @@
+const express = require("express");
+
+// Response routes: gather whispers from citizens as they commit to choices.
+const router = express.Router();
+
+router.post("/submit", (req, res) => {
+  const { user_id, poll_id, answer_json } = req.body;
+
+  // TODO: Store the response in the Supabase scrolls.
+  res.status(201).json({
+    message: "Response etched into the communal ledger.",
+    response: {
+      id: Date.now(),
+      user_id,
+      poll_id,
+      answer_json,
+      created_at: new Date().toISOString(),
+    },
+  });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,8 @@
+const app = require("./app");
+
+const PORT = process.env.PORT || 4000;
+
+// Signal fires are lit as the server awakens.
+app.listen(PORT, () => {
+  console.log(`Faction Flow Society Engine listening on port ${PORT}`);
+});

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,30 @@
+-- Faction Flow Society Engine schema
+-- These tables are the stone tablets of our digital society simulator.
+
+CREATE TABLE IF NOT EXISTS factions (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    motto TEXT,
+    daily_score NUMERIC DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    faction_id INTEGER REFERENCES factions(id),
+    profile_json JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS polls (
+    id SERIAL PRIMARY KEY,
+    question_text TEXT NOT NULL,
+    options_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS responses (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id),
+    poll_id INTEGER REFERENCES polls(id),
+    answer_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/frontend/components/DailyLeaderboard.js
+++ b/frontend/components/DailyLeaderboard.js
@@ -1,0 +1,24 @@
+import React from "react";
+
+// DailyLeaderboard: Displays the grand procession of factions ascending the rankings.
+// Whispered tales say the top faction receives extra resonance in the Nexus.
+const DailyLeaderboard = ({ standings = [] }) => {
+  return (
+    <div className="faction-card strategist-shine">
+      <h3 className="faction-title">Daily Faction Procession</h3>
+      <ol className="leaderboard-list">
+        {standings.length === 0 && <li>No factions reported today. The arena waits.</li>}
+        {standings.map((entry, index) => (
+          <li key={entry.name || index} className="leaderboard-entry">
+            <span className="rank">#{index + 1}</span>
+            <span className="name">{entry.name}</span>
+            <span className="score">{entry.score}</span>
+            <span className="badge">{entry.badge || "🛡️"}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+};
+
+export default DailyLeaderboard;

--- a/frontend/components/FactionScoreCard.js
+++ b/frontend/components/FactionScoreCard.js
@@ -1,0 +1,19 @@
+import React from "react";
+
+// FactionScoreCard: Chronicles the daily aura of your collective identity.
+// The Archivists etch these scores into the luminous walls each dusk.
+const FactionScoreCard = ({ factionName, motto, dailyScore, mood }) => {
+  return (
+    <div className="faction-card pioneer-flare">
+      <h3 className="faction-title">{factionName || "Unnamed Faction"}</h3>
+      <p className="faction-motto">{motto || "Awaiting motto from the elder council."}</p>
+      <div className="faction-score">
+        <span className="score-label">Daily Score:</span>
+        <span className="score-value">{dailyScore ?? "--"}</span>
+      </div>
+      <div className="faction-mood">Mood Signal: {mood || "undetected"}</div>
+    </div>
+  );
+};
+
+export default FactionScoreCard;

--- a/frontend/components/PollCard.js
+++ b/frontend/components/PollCard.js
@@ -1,0 +1,25 @@
+import React from "react";
+
+// PollCard: The oracle stone that presents daily dilemmas to citizens of the Faction Flow Society.
+// Legends say each choice tunes the harmonics of the digital realm.
+const PollCard = ({ question, options = [], onSelect, selectedOption }) => {
+  return (
+    <div className="faction-card guardian-glow">
+      <h2 className="faction-title">Daily Oracle</h2>
+      <p className="faction-question">{question || "Awaiting prophecy from the Council..."}</p>
+      <div className="faction-options">
+        {options.map((option, index) => (
+          <button
+            key={index}
+            className={`faction-option ${selectedOption === option ? "selected" : ""}`}
+            onClick={() => onSelect?.(option)}
+          >
+            {option}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PollCard;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "faction-flow-engine-frontend",
+  "version": "0.1.0",
+  "description": "Next.js plaza for the Faction Flow Society Engine",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,0 +1,6 @@
+import "../styles/global.css";
+
+// Custom App: keeps the plaza styling consistent across dimensions.
+export default function FactionApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,43 @@
+import React, { useState } from "react";
+import PollCard from "../components/PollCard";
+import FactionScoreCard from "../components/FactionScoreCard";
+import DailyLeaderboard from "../components/DailyLeaderboard";
+
+// Index page: Central plaza where citizens gather to witness the day's omens.
+const mockPoll = {
+  question: "How should the Council allocate today's energy reserves?",
+  options: ["Empower the Guardians", "Fortify the Pioneers", "Strategize with the Strategists", "Heal with the Harmonizers"],
+};
+
+const mockFaction = {
+  factionName: "Guardians of the Luminous Gate",
+  motto: "Stand watch, shine bright.",
+  dailyScore: 87,
+  mood: "optimistic",
+};
+
+const mockStandings = [
+  { name: "Guardians", score: 87, badge: "🛡️" },
+  { name: "Pioneers", score: 82, badge: "🚀" },
+  { name: "Strategists", score: 79, badge: "♟️" },
+  { name: "Harmonizers", score: 74, badge: "🕊️" },
+];
+
+const Home = () => {
+  const [selectedOption, setSelectedOption] = useState(null);
+
+  return (
+    <main className="plaza-grid">
+      <PollCard
+        question={mockPoll.question}
+        options={mockPoll.options}
+        selectedOption={selectedOption}
+        onSelect={setSelectedOption}
+      />
+      <FactionScoreCard {...mockFaction} />
+      <DailyLeaderboard standings={mockStandings} />
+    </main>
+  );
+};
+
+export default Home;

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -1,0 +1,81 @@
+:root {
+  --guardian: #4f46e5;
+  --pioneer: #16a34a;
+  --strategist: #f97316;
+  --harmonizer: #ec4899;
+  --plaza-bg: #0f172a;
+  --plaza-text: #e2e8f0;
+}
+
+body {
+  background: var(--plaza-bg);
+  color: var(--plaza-text);
+  font-family: "Trebuchet MS", sans-serif;
+  margin: 0;
+  padding: 2rem;
+}
+
+.plaza-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.faction-card {
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 0 20px rgba(15, 23, 42, 0.5);
+  background: rgba(15, 23, 42, 0.8);
+}
+
+.guardian-glow {
+  border: 2px solid var(--guardian);
+}
+
+.pioneer-flare {
+  border: 2px solid var(--pioneer);
+}
+
+.strategist-shine {
+  border: 2px solid var(--strategist);
+}
+
+.faction-title {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.faction-option {
+  display: block;
+  width: 100%;
+  margin-bottom: 0.5rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  background: rgba(59, 130, 246, 0.1);
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.faction-option.selected,
+.faction-option:hover {
+  transform: translateY(-2px);
+  border-color: var(--guardian);
+}
+
+.leaderboard-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.leaderboard-entry {
+  display: grid;
+  grid-template-columns: 3rem 1fr 4rem 3rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.05);
+}

--- a/scripts/aggregateStats.js
+++ b/scripts/aggregateStats.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+// aggregateStats: Ritual script invoked by the Midnight Assembly to interpret the day's signals.
+// Future upgrade: fetch from database, run AI-driven clustering, and emit to dashboards.
+const fs = require("fs");
+
+function summonFactionStats() {
+  return {
+    guardians: { participation: 0.76, mood: "optimistic" },
+    pioneers: { participation: 0.62, mood: "neutral" },
+    strategists: { participation: 0.81, mood: "focused" },
+    harmonizers: { participation: 0.55, mood: "empathetic" },
+  };
+}
+
+function main() {
+  const stats = summonFactionStats();
+  const output = JSON.stringify(stats, null, 2);
+  fs.writeFileSync("./daily_faction_report.json", output);
+  console.log(output);
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- establish a Next.js plaza with faction-flavored poll, score, and leaderboard components
- stand up an Express gateway with routes for polls, responses, and faction summaries plus lore-infused bots
- define Supabase-ready schema tables and add a daily analytics ritual script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3d3514414832da817c79b53cf509e