### PR TITLE
Add faction journey blueprint and reinforce schema security

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@ An early skeleton for a digital society simulator that unites citizens into fact
 ## Structure
 - `frontend/` – Next.js plaza housing faction-facing components.
 - `backend/` – Express gateway orchestrating poll, response, and faction summary routes.
-- `db/` – Postgres tablets defining the core tables.
+- `db/` – Postgres tablets defining the core tables with Supabase-flavoured RLS policies.
+- `docs/` – Lore scrolls outlining journeys, onboarding, and community scaffolding.
 - `scripts/` – Analytics rituals run by the Midnight Assembly.
 
 Each module embraces faction-flavored naming to keep the narrative spirit alive while leaving room for real integrations later on.
+
+## Journey Blueprint
+
+The `docs/faction-flow-journey.md` scroll captures the foundational idea, network rituals, and onboarding safeguards for Faction Flow. Use it as the guiding compass when extending data models, designing faction bots, or crafting daily rituals.

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,30 +1,68 @@
 -- Faction Flow Society Engine schema
 -- These tables are the stone tablets of our digital society simulator.
 
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE SCHEMA IF NOT EXISTS auth;
+
+CREATE OR REPLACE FUNCTION auth.uid()
+RETURNS uuid
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT NULLIF(current_setting('request.jwt.claim.sub', true), '')::uuid;
+$$;
+
 CREATE TABLE IF NOT EXISTS factions (
-    id SERIAL PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name TEXT NOT NULL,
     motto TEXT,
     daily_score NUMERIC DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS users (
-    id SERIAL PRIMARY KEY,
-    faction_id INTEGER REFERENCES factions(id),
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    faction_id UUID REFERENCES factions(id),
+    email_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    phone_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    device_hash TEXT,
+    trust_score INTEGER NOT NULL DEFAULT 0,
     profile_json JSONB DEFAULT '{}'::jsonb
 );
 
 CREATE TABLE IF NOT EXISTS polls (
-    id SERIAL PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     question_text TEXT NOT NULL,
     options_json JSONB NOT NULL,
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS responses (
-    id SERIAL PRIMARY KEY,
-    user_id INTEGER REFERENCES users(id),
-    poll_id INTEGER REFERENCES polls(id),
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES users(id),
+    poll_id UUID REFERENCES polls(id),
     answer_json JSONB NOT NULL,
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
+
+ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE responses ENABLE ROW LEVEL SECURITY;
+
+-- Example policies to illustrate protected access pathways.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'users' AND policyname = 'user_self_access'
+    ) THEN
+        EXECUTE 'CREATE POLICY user_self_access ON users USING (id = auth.uid())';
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'responses' AND policyname = 'response_ownership'
+    ) THEN
+        EXECUTE 'CREATE POLICY response_ownership ON responses USING (user_id = auth.uid())';
+    END IF;
+END $$;

--- a/docs/faction-flow-journey.md
+++ b/docs/faction-flow-journey.md
@@ -1,0 +1,47 @@
+# Faction Flow Journey Blueprint
+
+## Foundation
+- **Idea**: Faction Flow
+- **Core Mechanics**
+  - Community polls that fuel faction rivalries and cohesion.
+  - Personality tests that align recruits with their natural faction fit.
+  - Playful faction bots that curate member profiles and celebrate progress.
+- **North Star Goal**: Grow the network by guiding every citizen through structured polling rituals and deepening faction identity.
+
+## Network Strength
+
+### Social Glue
+- Rotating faction leaderboards that showcase collective wins and drive healthy competition.
+- Daily rituals including polls, check-ins, and mini debates that keep cadence and conversation alive.
+- Faction bots with humor, callbacks, and insider lore to reinforce belonging.
+
+### Structural Integrity
+- Supabase/Postgres stack protected with row-level security to guard personal data.
+- Clear separation between individual records and aggregated faction analytics.
+- Versioned poll and prompt templates so the canon can evolve without losing history.
+
+### Cultural Identity
+- Faction lore that grows as the community uncovers new narrative layers together.
+- Unlockable narrative beats that appear as trust and participation increase.
+- Daily digests and faction commentary that can be shared publicly to attract new recruits.
+
+## Onboarding Flow
+
+### Verification & Enrollment Steps
+1. Email plus phone one-time password verification anchors each identity.
+2. Device fingerprint binding ties the profile to trusted hardware.
+3. Maintain a single profile record per human with a rolling trust score.
+4. Introduce a "grey mode" experience for unverified or suspicious accounts until they earn trust.
+5. Grow the trust score through consistent positive interactions and faction contributions.
+
+### Data Model Highlights
+- `id` – UUID primary key for every user.
+- `email_verified` / `phone_verified` – Boolean flags after OTP confirmation.
+- `device_hash` – Fingerprint hash for device binding and anomaly detection.
+- `trust_score` – Integer meter that rises with healthy engagement.
+- `faction_id` – Nullable UUID to capture allegiance once the citizen chooses a faction.
+
+### Security Principles
+- All identifiers hashed or tokenized before storage or transmission.
+- Row-level security (RLS) policies gate access to personal records.
+- Faction-level penalties discourage duplicate account abuse and protect network trust.


### PR DESCRIPTION
## Summary
- add a faction flow journey blueprint document that narrates the idea, rituals, and onboarding safeguards
- refresh the README structure section to reference the new documentation and RLS-ready database tablets
- update the Postgres schema to use UUID identifiers, trust score fields, and illustrative row-level security policies with an auth.uid() helper

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3dbbb79bc832db7350e22b748b4fe