### PR TITLE
Add Prisma data scaffold for 4D live map

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Connection string for the Postgres database used by Prisma
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/4d_live_map"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+node_modules/
+dist/
+build/
+.env
+.prisma/
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ Each module embraces faction-flavored naming to keep the narrative spirit alive 
 ## Journey Blueprint
 
 The `docs/faction-flow-journey.md` scroll captures the foundational idea, network rituals, and onboarding safeguards for Faction Flow. Use it as the guiding compass when extending data models, designing faction bots, or crafting daily rituals.
+
+## 4D Live Map Scaffold
+
+To support experimentation with a time-aware terrain map, the repository now includes a Prisma + PostgreSQL data layer and seeding utilities.
+
+1. Copy `.env.example` to `.env` and adjust the `DATABASE_URL` for your Postgres or Supabase instance.
+2. Install dependencies with `npm install`.
+3. Apply the schema with `npm run db:push`.
+4. Populate demo data with `npm run seed`.
+
+The `scripts/push.sh` helper can be used to publish the repository to GitHub once `GITHUB_PAT` (and optionally `GITHUB_USERNAME`) are configured in your shell environment.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "4d-live-map",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "db:push": "prisma migrate deploy",
+    "prisma:generate": "prisma generate",
+    "seed": "ts-node --esm scripts/seed.ts"
+  },
+  "dependencies": {
+    "@faker-js/faker": "^8.4.1",
+    "@prisma/client": "^5.16.0",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "prisma": "^5.16.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5",
+    "@types/node": "^20.12.7"
+  }
+}

--- a/prisma/migrations/20240718000000_init/migration.sql
+++ b/prisma/migrations/20240718000000_init/migration.sql
@@ -1,0 +1,38 @@
+-- Create uuid generation extension for Prisma defaults
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE "users" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "email" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "users_email_key" UNIQUE ("email")
+);
+
+CREATE TYPE "EventType" AS ENUM ('point', 'trip');
+
+CREATE TABLE "events" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "user_id" UUID NOT NULL,
+    "type" "EventType" NOT NULL,
+    "lon" DOUBLE PRECISION NOT NULL,
+    "lat" DOUBLE PRECISION NOT NULL,
+    "altitude" DOUBLE PRECISION,
+    "timestamp" TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    "trail" JSONB NOT NULL,
+    CONSTRAINT "events_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "events_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "events_timestamp_idx" ON "events" ("timestamp");
+
+CREATE TABLE "timeline_states" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "user_id" UUID NOT NULL,
+    "current_time" TIMESTAMP(3) WITH TIME ZONE NOT NULL,
+    "speed" DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+    "playing" BOOLEAN NOT NULL DEFAULT TRUE,
+    CONSTRAINT "timeline_states_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "timeline_states_user_id_key" UNIQUE ("user_id"),
+    CONSTRAINT "timeline_states_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,51 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum EventType {
+  point
+  trip
+}
+
+model User {
+  id             String          @id @default(uuid())
+  email          String          @unique
+  createdAt      DateTime        @default(now()) @map("created_at")
+  events         Event[]
+  timelineStates TimelineState[]
+
+  @@map("users")
+}
+
+model Event {
+  id        String    @id @default(uuid())
+  userId    String    @map("user_id")
+  type      EventType
+  lon       Float
+  lat       Float
+  altitude  Float?
+  timestamp DateTime
+  trail     Json
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([timestamp])
+  @@map("events")
+}
+
+model TimelineState {
+  id          String   @id @default(uuid())
+  userId      String   @unique @map("user_id")
+  currentTime DateTime @map("current_time")
+  speed       Float    @default(1.0)
+  playing     Boolean  @default(true)
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("timeline_states")
+}

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d .git ]; then
+  git init
+fi
+
+: "${GITHUB_PAT:?Set the GITHUB_PAT environment variable with a GitHub personal access token}";
+GITHUB_USERNAME="${GITHUB_USERNAME:-your-github-username}"
+
+current_remote="$(git remote get-url origin 2>/dev/null || true)"
+if [ -n "$current_remote" ]; then
+  git remote remove origin
+fi
+
+git remote add origin "https://${GITHUB_PAT}@github.com/${GITHUB_USERNAME}/4d-live-map.git"
+git branch -M main
+
+echo "Pushing current branch to GitHub..."
+git push -u origin HEAD

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,84 @@
+import 'dotenv/config';
+import { faker } from '@faker-js/faker';
+import { insertEvent, prisma, EventType, TrailPoint, updateTimelineState } from '../src/db.js';
+
+const TEST_USER_EMAIL = 'pilot@example.com';
+const EVENT_COUNT = 20;
+
+function buildTrail(type: EventType, origin: { lon: number; lat: number }): TrailPoint[] {
+  if (type === EventType.point) {
+    const altitude = faker.number.float({ min: 0, max: 5000, precision: 0.1 });
+    return [[origin.lon, origin.lat, altitude]];
+  }
+
+  const segments = faker.number.int({ min: 3, max: 8 });
+  const baseAltitude = faker.number.float({ min: 0, max: 4000, precision: 0.1 });
+  const trail: TrailPoint[] = [];
+
+  for (let i = 0; i < segments; i++) {
+    const lonOffset = faker.number.float({ min: -0.05, max: 0.05, precision: 0.0001 });
+    const latOffset = faker.number.float({ min: -0.05, max: 0.05, precision: 0.0001 });
+    const altitudeOffset = faker.number.float({ min: -200, max: 200, precision: 0.1 });
+
+    trail.push([
+      origin.lon + lonOffset,
+      origin.lat + latOffset,
+      baseAltitude + altitudeOffset,
+    ]);
+  }
+
+  return trail;
+}
+
+async function seed() {
+  const user = await prisma.user.upsert({
+    where: { email: TEST_USER_EMAIL },
+    update: {},
+    create: {
+      email: TEST_USER_EMAIL,
+    },
+  });
+
+  await prisma.event.deleteMany({ where: { userId: user.id } });
+
+  const now = new Date();
+  const startTime = new Date(now.getTime() - 1000 * 60 * 60 * 24 * 3);
+
+  for (let i = 0; i < EVENT_COUNT; i++) {
+    const type = i % 3 === 0 ? EventType.trip : EventType.point;
+    const lon = parseFloat(faker.location.longitude());
+    const lat = parseFloat(faker.location.latitude());
+    const altitude = type === EventType.point
+      ? faker.number.float({ min: 0, max: 5000, precision: 0.1 })
+      : null;
+    const timestamp = new Date(startTime.getTime() + faker.number.int({ min: 0, max: now.getTime() - startTime.getTime() }));
+    const trail = buildTrail(type, { lon, lat });
+
+    await insertEvent({
+      userId: user.id,
+      type,
+      lon,
+      lat,
+      altitude,
+      timestamp,
+      trail,
+    });
+  }
+
+  await updateTimelineState(user.id, {
+    currentTime: now,
+    speed: 1.0,
+    playing: true,
+  });
+
+  console.log(`Seeded ${EVENT_COUNT} events for ${TEST_USER_EMAIL}.`);
+}
+
+seed()
+  .catch((error) => {
+    console.error('Failed to seed database:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,74 @@
+import 'dotenv/config';
+import { PrismaClient, EventType, Prisma } from '@prisma/client';
+
+export type TrailPoint = [number, number, number?];
+
+export interface EventInput {
+  id?: string;
+  userId: string;
+  type: EventType;
+  lon: number;
+  lat: number;
+  altitude?: number | null;
+  timestamp: Date;
+  trail: TrailPoint[];
+}
+
+export interface TimelineStateUpdate {
+  currentTime?: Date;
+  speed?: number;
+  playing?: boolean;
+}
+
+const prisma = new PrismaClient();
+
+function toJsonArray(trail: TrailPoint[]): Prisma.JsonArray {
+  return trail.map((point) => point as unknown as Prisma.JsonValue) as Prisma.JsonArray;
+}
+
+export async function insertEvent(event: EventInput) {
+  return prisma.event.create({
+    data: {
+      id: event.id,
+      userId: event.userId,
+      type: event.type,
+      lon: event.lon,
+      lat: event.lat,
+      altitude: event.altitude ?? null,
+      timestamp: event.timestamp,
+      trail: toJsonArray(event.trail),
+    },
+  });
+}
+
+export async function getEventsSince(since: Date) {
+  return prisma.event.findMany({
+    where: {
+      timestamp: {
+        gte: since,
+      },
+    },
+    orderBy: {
+      timestamp: 'asc',
+    },
+  });
+}
+
+export async function updateTimelineState(userId: string, state: TimelineStateUpdate) {
+  const data = {
+    currentTime: state.currentTime ?? new Date(),
+    speed: state.speed ?? 1.0,
+    playing: state.playing ?? true,
+  };
+
+  return prisma.timelineState.upsert({
+    where: { userId },
+    update: data,
+    create: {
+      userId,
+      ...data,
+    },
+  });
+}
+
+export { prisma, EventType };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "scripts/**/*", "prisma/**/*"],
+  "ts-node": {
+    "esm": true,
+    "experimentalSpecifierResolution": "node"
+  }
+}


### PR DESCRIPTION
## Summary
- add Prisma schema and SQL migration for users, events, and timeline state tables
- scaffold Node/TypeScript utilities for inserting events and managing timeline playback state
- provide seed and GitHub push helper scripts plus README guidance and environment template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea370b9f88832d9d394767791b6f01